### PR TITLE
Update analytics JSON to use "c", "e", and "p" in the body.

### DIFF
--- a/Plugins/BeamableCore/Source/BeamableCoreRuntime/Private/Runtime/BeamRuntime.cpp
+++ b/Plugins/BeamableCore/Source/BeamableCoreRuntime/Private/Runtime/BeamRuntime.cpp
@@ -2108,9 +2108,9 @@ void UBeamRuntime::SendAnalyticsEvent(const FUserSlot& Slot, const FString& Even
 		TSharedPtr<FJsonObject> TopJsonObject = MakeShareable(new FJsonObject);
 
 		TopJsonObject->SetStringField(TEXT("op"), EventOpCode);
-		TopJsonObject->SetStringField(TEXT("category"), EventCategory);
-		TopJsonObject->SetStringField(TEXT("event"), EventName);
-		TopJsonObject->SetObjectField(TEXT("params"), EventParamsObj[i]);
+		TopJsonObject->SetStringField(TEXT("c"), EventCategory);
+		TopJsonObject->SetStringField(TEXT("e"), EventName);
+		TopJsonObject->SetObjectField(TEXT("p"), EventParamsObj[i]);
 
 		// Serialize the FJsonObject to a string
 		FString AnalyticsEvent;


### PR DESCRIPTION
Fixes #94 

The backend will fail to consume any analytics message that does not have `"op"`, `"c"`, `"e"`, and `"p"` fields. The `"p"` field's value is allowed to be an empty array if there are no properties/parameters.